### PR TITLE
fix: Add required ASF policy links and fix privacy URL

### DIFF
--- a/theme/apache/templates/base.html
+++ b/theme/apache/templates/base.html
@@ -87,7 +87,7 @@ limitations under the License.
                                                             <li><a href="/documentation.html" title="Documentation">Documentation</a></li>
                                                             <li><a href="/site-index.html" title="Site Index">Site Index</a></li>
                                                             <li><a href="/license.html" title="License">License</a></li>
-                                                            <li><a href="/privacy-policy.html" title="Privacy Policy">Privacy Policy</a></li>
+                                                            <li><a href="https://privacy.apache.org/policies/privacy-policy-public.html" title="Privacy Policy">Privacy Policy</a></li>
                                                         </ul>
 
                                                         <h3><a name="SideNav-Community"></a><a href="/community.html" title="Community">Community</a></h3>
@@ -165,8 +165,16 @@ limitations under the License.
             </div>
             <div class="design_attribution">
                 Copyright &copy; 2006,{{CURRENTYEAR}} The Apache Software Foundation. Licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>.<br />
-                Apache, the Apache feather logo and OpenJPA are trademarks of The Apache Software Foundation.<br />
-                Other names may be trademarks of their respective owners.<br />
+                Apache OpenJPA, OpenJPA, Apache, the Apache logo, and the Apache OpenJPA project logo are either
+                registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.<br />
+                <br />
+                <a href="https://www.apache.org/">Foundation</a> |
+                <a href="https://www.apache.org/events/current-event.html">Events</a> |
+                <a href="https://www.apache.org/licenses/">License</a> |
+                <a href="https://www.apache.org/security/">Security</a> |
+                <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
+                <a href="https://www.apache.org/foundation/thanks.html">Thanks</a> |
+                <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a>
             </div>
     </body>
 </html>


### PR DESCRIPTION
The OpenJPA website is failing 6 of 9 ASF website policy checks (https://whimsy.apache.org/site/):

- Events (missing)
- License (missing from footer)
- Thanks (sidebar points to project-level page; ASF link missing)
- Security (missing)
- Sponsorship (missing)
- Privacy (sidebar pointed to project-level page)

This PR:
- Updates the sidebar "Privacy Policy" link to the canonical ASF URL
- Adds a full ASF policy links row in the footer (Foundation, Events, License, Security, Sponsorship, Thanks, Privacy)
- Updates trademark text ("Apache feather logo" → "Apache logo")

Note: The site also still uses the old ASF feather logo in the header (the ASF rebranded to an oak leaf logo in September 2025). Happy to follow up with a properly-sized replacement image if desired.

See: https://www.apache.org/foundation/marks/pmcs
Checker: https://whimsy.apache.org/site/